### PR TITLE
Convert Install from Web script

### DIFF
--- a/media/plg_installer_webinstaller/js/client.es6.js
+++ b/media/plg_installer_webinstaller/js/client.es6.js
@@ -1,0 +1,359 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+if (!window.jQuery) {
+  throw new Error('WebInstaller plugin requires jQuery');
+}
+
+if (!Joomla) {
+  throw new Error('Joomla API is not properly initialised');
+}
+
+// TODO - Update server layouts for 4.0 to remove global var use
+const apps_base_url = Joomla.getOptions('plg_installer_webinstaller', {}).base_url;
+
+((window, document, Joomla, jQuery) => {
+  'use strict';
+
+  const webInstallerOptions = {
+    view: 'dashboard',
+    id: 0,
+    ordering: '',
+    list: 0,
+    options: Joomla.getOptions('plg_installer_webinstaller', {}),
+  };
+
+  let instance;
+
+  class WebInstaller {
+    initialise() {
+      webInstallerOptions.loaded = 1;
+
+      if (document.getElementById('myTabContent')) {
+        const webTab = document.getElementById('web');
+        const cancelButton = document.getElementById('uploadform-web-cancel');
+
+        cancelButton.addEventListener('click', () => {
+          document.getElementById('uploadform-web').classList.add('hidden');
+
+          // jQuery('#jed-container').slideDown(300);
+          if (webInstallerOptions.list && document.querySelector('.list-view')) {
+            document.querySelector('.list-view').click();
+          }
+        });
+
+        webTab.insertAdjacentHTML('afterbegin', '<div id="appsloading" class="ifw-loading-container"></div>');
+        webTab.style.position = 'absolute';
+
+        jQuery('#appsloading').on('ajaxStart', () => {
+          document.body.classList.add('ifw-busy');
+          document.getElementById('appsloading').classList.remove('hidden');
+        }).on('ajaxStop', () => {
+          document.getElementById('appsloading').classList.add('hidden');
+          document.body.classList.remove('ifw-busy');
+        });
+      }
+
+      this.loadweb(`${webInstallerOptions.options.base_url}index.php?format=json&option=com_apps&view=dashboard`);
+
+      this.clickforlinks();
+    }
+
+    loadweb(url) {
+      if (!url) {
+        return false;
+      }
+
+      const self = this;
+      const pattern1 = new RegExp(webInstallerOptions.options.base_url);
+      const pattern2 = new RegExp('^index.php');
+
+      if (!(pattern1.test(url) || pattern2.test(url))) {
+        window.open(url, '_blank');
+
+        return false;
+      }
+
+      let requestUrl = `${url}&product=${webInstallerOptions.options.product}&release=${webInstallerOptions.options.release}&dev_level=${webInstallerOptions.options.dev_level}&list=${webInstallerOptions.list ? 'list' : 'grid'}&lang=${webInstallerOptions.options.language}`;
+
+      if (webInstallerOptions.ordering !== '' && document.getElementById('com-apps-ordering').value) {
+        webInstallerOptions.ordering = document.getElementById('com-apps-ordering').value;
+        requestUrl += `&ordering=${webInstallerOptions.ordering}`;
+      }
+
+      // jQuery('html, body').animate({ scrollTop: 0 }, 0);
+      if (document.getElementById('myTabContent')) {
+        const element = document.getElementById('appsloading');
+        element.style.position = 'absolute';
+        element.style.left = '0';
+        element.style.top = '0';
+        element.style.width = '100%';
+        element.style.height = '100%';
+
+        const web = document.getElementById('web');
+        web.style.position = 'relative';
+        web.appendChild(element);
+
+        jQuery('#appsloading').trigger('ajaxStart');
+      }
+
+      // @todo convert to vanilla, (why JSONP?)
+      jQuery.ajax({
+        url: requestUrl,
+        dataType: 'jsonp',
+        cache: true,
+        jsonpCallback: 'jedapps_jsonpcallback',
+        timeout: 20000,
+        success(response) {
+          if (document.getElementById('web-loader')) {
+            document.getElementById('web-loader').classList.add('hidden');
+          }
+
+          const jedContainer = document.getElementById('jed-container');
+          jedContainer.innerHTML = response.data.html;
+
+          document.getElementById('com-apps-searchbox').addEventListener('keypress', (event) => {
+            if (event.which === 13) {
+              self.initiateSearch();
+            }
+          });
+
+          document.getElementById('search-reset').addEventListener('click', () => {
+            const searchBox = document.getElementById('com-apps-searchbox');
+            searchBox.value = '';
+            self.initiateSearch();
+          });
+
+          const orderingSelect = document.getElementById('com-apps-ordering');
+
+          if (orderingSelect) {
+            orderingSelect.addEventListener('change', () => {
+              const index = orderingSelect.selectedIndex;
+              webInstallerOptions.ordering = orderingSelect.options[index].value;
+              self.installfromwebajaxsubmit();
+            });
+          }
+
+          if (webInstallerOptions.options.installfrom_url !== '') {
+            WebInstaller.installfromweb(webInstallerOptions.options.installfrom_url);
+          }
+        },
+        fail() {
+          if (document.getElementById('web-loader')) {
+            document.getElementById('web-loader').classList.add('hidden');
+            document.getElementById('web-loader-error').classList.remove('hidden');
+          }
+        },
+        complete() {
+          const installAtField = document.getElementById('joomlaapsinstallatinput');
+
+          if (installAtField) {
+            installAtField.value = webInstallerOptions.options.installat_url;
+          }
+
+          self.clickforlinks();
+          WebInstaller.clicker();
+
+          if (webInstallerOptions.list && document.querySelector('.list-view')) {
+            document.querySelector('.list-view').click();
+          }
+
+          if (document.getElementById('myTabContent')) {
+            jQuery('#appsloading').trigger('ajaxStop');
+          }
+        },
+        error(request) {
+          const errorContainer = document.getElementById('web-loader-error');
+          const loaderContainer = document.getElementById('web-loader');
+
+          if (request.responseText && errorContainer) {
+            errorContainer.innerHTML = request.responseText;
+          }
+
+          if (loaderContainer) {
+            loaderContainer.classList.add('hidden');
+            errorContainer.classList.remove('hidden');
+          }
+        },
+      });
+
+      return true;
+    }
+
+    clickforlinks() {
+      const self = this;
+
+      [].slice.call(document.querySelectorAll('a.transcode')).forEach((element) => {
+        const ajaxurl = element.getAttribute('href');
+
+        element.addEventListener('click', (event) => {
+          const pattern1 = new RegExp(webInstallerOptions.options.base_url);
+          const pattern2 = new RegExp('^index.php');
+
+          if (pattern1.test(ajaxurl) || pattern2.test(ajaxurl)) {
+            webInstallerOptions.view = ajaxurl.replace(/^.+[&?]view=(\w+).*$/, '$1');
+
+            if (webInstallerOptions.view === 'dashboard') {
+              webInstallerOptions.id = 0;
+            } else if (webInstallerOptions.view === 'category') {
+              webInstallerOptions.id = ajaxurl.replace(/^.+[&?]id=(\d+).*$/, '$1');
+            }
+
+            event.preventDefault();
+            self.loadweb(webInstallerOptions.options.base_url + ajaxurl);
+          } else {
+            event.preventDefault();
+            self.loadweb(ajaxurl);
+          }
+        });
+
+        element.setAttribute('href', '#');
+      });
+    }
+
+    initiateSearch() {
+      webInstallerOptions.view = 'dashboard';
+      this.installfromwebajaxsubmit();
+    }
+
+    installfromwebajaxsubmit() {
+      let tail = `&view=${webInstallerOptions.view}`;
+
+      if (webInstallerOptions.id) {
+        tail += `&id=${webInstallerOptions.id}`;
+      }
+
+      if (document.getElementById('com-apps-searchbox').value) {
+        const value = encodeURI(document.getElementById('com-apps-searchbox').value.toLowerCase().replace(/ +/g, '_').replace(/[^a-z0-9-_]/g, '').trim());
+        tail += `&filter_search=${value}`;
+      }
+
+      if (webInstallerOptions.ordering !== '' && document.getElementById('com-apps-ordering').value) {
+        webInstallerOptions.ordering = document.getElementById('com-apps-ordering').value;
+      }
+
+      if (webInstallerOptions.ordering) {
+        tail += `&ordering=${webInstallerOptions.ordering}`;
+      }
+
+      this.loadweb(`${webInstallerOptions.options.base_url}index.php?format=json&option=com_apps${tail}`);
+    }
+
+    static clicker() {
+      if (document.querySelector('.grid-view')) {
+        document.querySelector('.grid-view').addEventListener('click', () => {
+          webInstallerOptions.list = 0;
+          document.querySelector('.list-container').classList.add('hidden');
+          document.querySelector('.grid-container').classList.remove('hidden');
+          document.getElementById('btn-list-view').classList.remove('active');
+          document.getElementById('btn-grid-view').classList.remove('active');
+        });
+      }
+
+      if (document.querySelector('.list-view')) {
+        document.querySelector('.list-view').addEventListener('click', () => {
+          webInstallerOptions.list = 1;
+          document.querySelector('.grid-container').classList.add('hidden');
+          document.querySelector('.list-container').classList.remove('hidden');
+          document.getElementById('btn-grid-view').classList.remove('active');
+          document.getElementById('btn-list-view').classList.add('active');
+        });
+      }
+    }
+
+    /**
+     * @param {string} installUrl
+     * @param {string} name
+     * @returns {boolean}
+     * @todo Migrate this function's alert to a CE dialog
+     * @todo Migrate this function's hardcoded English string to Joomla.JText
+     */
+    static installfromweb(installUrl, name) {
+      if (!installUrl) {
+        alert("This extension cannot be installed via the web. Please visit the developer's website to purchase/download.");
+
+        return false;
+      }
+
+      const installUrlField = document.getElementById('install_url');
+      const uploadUrlContainer = document.getElementById('uploadform-web-url');
+
+      installUrlField.value = installUrl;
+      uploadUrlContainer.innerHTML = installUrl;
+
+      if (name) {
+        const nameElement = document.getElementById('uploadform-web-name');
+        nameElement.innerHTML = name;
+        document.getElementById('uploadform-web-name-label').classList.remove('hidden');
+      } else {
+        document.getElementById('uploadform-web-name-label').classList.add('hidden');
+      }
+
+      // jQuery('#jed-container').slideUp(300);
+      document.getElementById('uploadform-web').classList.remove('hidden');
+
+      return true;
+    }
+
+    /**
+     * Onclick handler for the button#appssubmitbutton element
+     *
+     * @param {string} redirectUrl
+     * @returns {boolean}
+     * @todo Convert from inline onclick registration, requires coordinated PR to IFW repo
+     * @todo Migrate this function's confirm to a CE dialog
+     * @todo Migrate this function's hardcoded English string to Joomla.JText
+     */
+    static installfromwebexternal(redirectUrl) {
+      const redirectConfirm = confirm(`You will be redirected to the following link to complete the registration/purchase - \n${redirectUrl}`);
+
+      if (redirectConfirm === true) {
+        document.getElementById('adminForm').setAttribute('action', redirectUrl);
+        document.querySelector('input[name=task]').setAttribute('disabled', true);
+        document.querySelector('input[name=install_directory]').setAttribute('disabled', true);
+        document.querySelector('input[name=install_url]').setAttribute('disabled', true);
+        document.querySelector('input[name=installtype]').setAttribute('disabled', true);
+        document.querySelector('input[name=filter_search]').setAttribute('disabled', true);
+
+        return true;
+      }
+
+      return false;
+    }
+  }
+
+  jQuery(($) => {
+    const link = $('#myTabTabs').find('a[href="#web"]');
+
+    if (webInstallerOptions.options.installfromon) {
+      link.click();
+    }
+
+    if (link.hasClass('active')) {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    }
+
+    link.closest('li').click(() => {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    });
+
+    if (webInstallerOptions.options.installfrom_url !== '') {
+      link.closest('li').click();
+    }
+
+    link.on('shown.bs.tab', () => {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    });
+  });
+})(window, document, Joomla, window.jQuery);

--- a/media/plg_installer_webinstaller/js/client.js
+++ b/media/plg_installer_webinstaller/js/client.js
@@ -1,313 +1,387 @@
 /**
+* PLEASE DO NOT MODIFY THIS FILE. WORK ON THE ES6 VERSION.
+* OTHERWISE YOUR CHANGES WILL BE REPLACED ON THE NEXT BUILD.
+**/
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
  * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-if (!Joomla) {
-	throw new Error('Joomla API is not properly initialised');
+if (!window.jQuery) {
+  throw new Error('WebInstaller plugin requires jQuery');
 }
 
-// For compatibility with the layouts coming from the remote server, continue exposing some of the old global vars
+if (!Joomla) {
+  throw new Error('Joomla API is not properly initialised');
+}
+
+// TODO - Update server layouts for 4.0 to remove global var use
 var apps_base_url = Joomla.getOptions('plg_installer_webinstaller', {}).base_url;
 
 (function (window, document, Joomla, jQuery) {
-	Joomla.apps = {
-		view: "dashboard",
-		id: 0,
-		ordering: "",
-		cssfiles: [],
-		jsfiles: [],
-		list: 0,
-		loaded: 0,
-		options: Joomla.getOptions('plg_installer_webinstaller', {}),
-	};
+  'use strict';
 
-	Joomla.loadweb = function (url) {
-		if (!url) {
-			return false;
-		}
+  var webInstallerOptions = {
+    view: 'dashboard',
+    id: 0,
+    ordering: '',
+    list: 0,
+    options: Joomla.getOptions('plg_installer_webinstaller', {})
+  };
 
-		var pattern1 = new RegExp(Joomla.apps.options.base_url);
-		var pattern2 = new RegExp("^index\.php");
+  var instance = void 0;
 
-		if (!(pattern1.test(url) || pattern2.test(url))) {
-			window.open(url, "_blank");
+  var WebInstaller = function () {
+    function WebInstaller() {
+      _classCallCheck(this, WebInstaller);
+    }
 
-			return false;
-		}
+    _createClass(WebInstaller, [{
+      key: 'initialise',
+      value: function initialise() {
+        webInstallerOptions.loaded = 1;
 
-		url += '&product=' + Joomla.apps.options.product + '&release=' + Joomla.apps.options.release + '&dev_level=' + Joomla.apps.options.dev_level + '&list=' + (Joomla.apps.list ? 'list' : 'grid') + '&lang=' + Joomla.apps.options.language;
+        if (document.getElementById('myTabContent')) {
+          var webTab = document.getElementById('web');
+          var cancelButton = document.getElementById('uploadform-web-cancel');
 
-		if (Joomla.apps.ordering !== "" && document.querySelector('#com-apps-ordering').value) {
-			Joomla.apps.ordering = document.querySelector('#com-apps-ordering').value;
-			url += '&ordering=' + Joomla.apps.ordering;
-		}
+          cancelButton.addEventListener('click', function () {
+            document.getElementById('uploadform-web').classList.add('hidden');
 
-		//jQuery('html, body').animate({ scrollTop: 0 }, 0);
-		if (document.querySelector('#myTabContent')) {
-			var element = document.querySelector('#appsloading');
-			element.style.position = "absolute";
-			element.style.left = "0";
-			element.style.top = "0";
-			element.style.width = "100%";
-			element.style.height = "100%";
+            // jQuery('#jed-container').slideDown(300);
+            if (webInstallerOptions.list && document.querySelector('.list-view')) {
+              document.querySelector('.list-view').click();
+            }
+          });
 
-			document.querySelector('#web').style.position = 'relative';
-			document.querySelector('#web').appendChild(element);
+          webTab.insertAdjacentHTML('afterbegin', '<div id="appsloading" class="ifw-loading-container"></div>');
+          webTab.style.position = 'absolute';
 
-			jQuery('#appsloading').trigger("ajaxStart");
-		}
+          jQuery('#appsloading').on('ajaxStart', function () {
+            document.body.classList.add('ifw-busy');
+            document.getElementById('appsloading').classList.remove('hidden');
+          }).on('ajaxStop', function () {
+            document.getElementById('appsloading').classList.add('hidden');
+            document.body.classList.remove('ifw-busy');
+          });
+        }
 
-		// @todo convert to vanilla, (why JSONP?)
-		jQuery.ajax({
-			url: url,
-			dataType: 'jsonp',
-			cache: true,
-			jsonpCallback: "jedapps_jsonpcallback",
-			timeout: 20000,
-			success: function (response) {
-				if (document.querySelector('#web-loader')) {
-					document.querySelector('#web-loader').classList.add('hidden');
-				}
+        this.loadweb(webInstallerOptions.options.base_url + 'index.php?format=json&option=com_apps&view=dashboard');
 
-				document.querySelector('#jed-container').innerHTML = response.data.html;
+        this.clickforlinks();
+      }
+    }, {
+      key: 'loadweb',
+      value: function loadweb(url) {
+        if (!url) {
+          return false;
+        }
 
-				document.querySelector('#com-apps-searchbox').addEventListener('keypress', function (event) {
-					if (event.which == 13) {
-						Joomla.apps.initiateSearch();
-					}
-				});
+        var self = this;
+        var pattern1 = new RegExp(webInstallerOptions.options.base_url);
+        var pattern2 = new RegExp('^index.php');
 
-				document.querySelector('#search-reset').addEventListener('click', function (event) {
-					document.querySelector('#com-apps-searchbox').value = '';
-					Joomla.apps.initiateSearch();
-				});
+        if (!(pattern1.test(url) || pattern2.test(url))) {
+          window.open(url, '_blank');
 
-				if (document.querySelector('#com-apps-ordering')) {
-					document.querySelector('#com-apps-ordering').addEventListener('change', function (event) {
-						Joomla.apps.ordering = jQuery(this).prop("selectedIndex");
-						Joomla.installfromwebajaxsubmit();
-					});
-				}
+          return false;
+        }
 
-				if (Joomla.apps.options.installfrom_url !== '') {
-					Joomla.installfromweb(Joomla.apps.options.installfrom_url);
-				}
-			},
-			fail: function () {
-				if (document.querySelector('#web-loader')) {
-					document.querySelector('#web-loader').classList.add('hidden');
-					document.querySelector('#web-loader-error').classList.remove('hidden');
-				}
-			},
-			complete: function () {
-				if (document.querySelector('#joomlaapsinstallatinput')) {
-					document.querySelector('#joomlaapsinstallatinput').value = Joomla.apps.options.installat_url;
-				}
+        var requestUrl = url + '&product=' + webInstallerOptions.options.product + '&release=' + webInstallerOptions.options.release + '&dev_level=' + webInstallerOptions.options.dev_level + '&list=' + (webInstallerOptions.list ? 'list' : 'grid') + '&lang=' + webInstallerOptions.options.language;
 
-				Joomla.apps.clickforlinks();
-				Joomla.apps.clicker();
+        if (webInstallerOptions.ordering !== '' && document.getElementById('com-apps-ordering').value) {
+          webInstallerOptions.ordering = document.getElementById('com-apps-ordering').value;
+          requestUrl += '&ordering=' + webInstallerOptions.ordering;
+        }
 
-				if (Joomla.apps.list && document.querySelector(".list-view")) {
-					document.querySelector(".list-view").click();
-				}
+        // jQuery('html, body').animate({ scrollTop: 0 }, 0);
+        if (document.getElementById('myTabContent')) {
+          var element = document.getElementById('appsloading');
+          element.style.position = 'absolute';
+          element.style.left = '0';
+          element.style.top = '0';
+          element.style.width = '100%';
+          element.style.height = '100%';
 
-				if (document.querySelector('#myTabContent')) {
-					jQuery('#appsloading').trigger("ajaxStop");
-				}
-			},
-			error: function (request, status, error) {
-				if (request.responseText && document.querySelector('#web-loader-error')) {
-					document.querySelector('#web-loader-error').innerHTML = request.responseText;
-				}
+          var web = document.getElementById('web');
+          web.style.position = 'relative';
+          web.appendChild(element);
 
-				if (document.querySelector('#web-loader')) {
-					document.querySelector('#web-loader').classList.add('hidden');
-					document.querySelector('#web-loader-error').classList.remove('hidden');
-				}
-			}
-		});
-		return true;
-	};
+          jQuery('#appsloading').trigger('ajaxStart');
+        }
 
-	Joomla.webpaginate = function (url, target) {
-		document.querySelector('#web-paginate-loader').classList.remove('hidden');
+        // @todo convert to vanilla, (why JSONP?)
+        jQuery.ajax({
+          url: requestUrl,
+          dataType: 'jsonp',
+          cache: true,
+          jsonpCallback: 'jedapps_jsonpcallback',
+          timeout: 20000,
+          success: function success(response) {
+            if (document.getElementById('web-loader')) {
+              document.getElementById('web-loader').classList.add('hidden');
+            }
 
-		jQuery.get(url, function (response) {
-			document.querySelector('#web-paginate-loader').classList.add('hidden');
-			document.querySelector('#' + target).innerHTML = response.data.html;
-		}, 'jsonp').fail(function () {
-			document.querySelector('#web-paginate-loader').classList.add('hidden');
-		});
-	};
+            var jedContainer = document.getElementById('jed-container');
+            jedContainer.innerHTML = response.data.html;
 
-	Joomla.installfromwebexternal = function (redirect_url) {
-		// @todo trnslatable string from PHP
-		var redirect_confirm = confirm('You will be redirected to the following link to complete the registration/purchase - \n' + redirect_url);
+            document.getElementById('com-apps-searchbox').addEventListener('keypress', function (event) {
+              if (event.which === 13) {
+                self.initiateSearch();
+              }
+            });
 
-		if (true == redirect_confirm) {
-			document.querySelector('#adminForm').setAttribute('action', redirect_url);
-			document.querySelector("input[name=task]").setAttribute("disabled", true);
-			document.querySelector("input[name=install_directory]").setAttribute("disabled", true);
-			document.querySelector("input[name=install_url]").setAttribute("disabled", true);
-			document.querySelector("input[name=installtype]").setAttribute("disabled", true);
-			document.querySelector("input[name=filter_search]").setAttribute("disabled", true);
+            document.getElementById('search-reset').addEventListener('click', function () {
+              var searchBox = document.getElementById('com-apps-searchbox');
+              searchBox.value = '';
+              self.initiateSearch();
+            });
 
-			return true;
-		}
+            var orderingSelect = document.getElementById('com-apps-ordering');
 
-		return false;
-	};
+            if (orderingSelect) {
+              orderingSelect.addEventListener('change', function () {
+                var index = orderingSelect.selectedIndex;
+                webInstallerOptions.ordering = orderingSelect.options[index].value;
+                self.installfromwebajaxsubmit();
+              });
+            }
 
-	Joomla.installfromweb = function (install_url, name) {
-		if (!install_url) {
-			// @todo trnslatable string from PHP
-			alert("This extension cannot be installed via the web. Please visit the developer's website to purchase/download.");
+            if (webInstallerOptions.options.installfrom_url !== '') {
+              WebInstaller.installfromweb(webInstallerOptions.options.installfrom_url);
+            }
+          },
+          fail: function fail() {
+            if (document.getElementById('web-loader')) {
+              document.getElementById('web-loader').classList.add('hidden');
+              document.getElementById('web-loader-error').classList.remove('hidden');
+            }
+          },
+          complete: function complete() {
+            var installAtField = document.getElementById('joomlaapsinstallatinput');
 
-			return false;
-		}
+            if (installAtField) {
+              installAtField.value = webInstallerOptions.options.installat_url;
+            }
 
-		document.querySelector('#install_url').value = install_url;
-		document.querySelector('#uploadform-web-url').innerHTML = install_url;
+            self.clickforlinks();
+            WebInstaller.clicker();
 
-		if (name) {
-			document.querySelector('#uploadform-web-name').innerHTML = name;
-			document.querySelector('#uploadform-web-name-label').classList.remove('hidden');
-		} else {
-			document.querySelector('#uploadform-web-name-label').classList.add('hidden');
-		}
+            if (webInstallerOptions.list && document.querySelector('.list-view')) {
+              document.querySelector('.list-view').click();
+            }
 
-		// jQuery('#jed-container').slideUp(300);
-		document.querySelector('#uploadform-web').classList.remove('hidden');
+            if (document.getElementById('myTabContent')) {
+              jQuery('#appsloading').trigger('ajaxStop');
+            }
+          },
+          error: function error(request) {
+            var errorContainer = document.getElementById('web-loader-error');
+            var loaderContainer = document.getElementById('web-loader');
 
-		return true;
-	};
+            if (request.responseText && errorContainer) {
+              errorContainer.innerHTML = request.responseText;
+            }
 
-	Joomla.installfromwebcancel = function () {
-		document.querySelector('#uploadform-web').classList.add('hidden');
+            if (loaderContainer) {
+              loaderContainer.classList.add('hidden');
+              errorContainer.classList.remove('hidden');
+            }
+          }
+        });
 
-		// jQuery('#jed-container').slideDown(300);
-		if (Joomla.apps.list && document.querySelector(".list-view")) {
-			document.querySelector(".list-view").click();
-		}
-	};
+        return true;
+      }
+    }, {
+      key: 'clickforlinks',
+      value: function clickforlinks() {
+        var self = this;
 
-	Joomla.installfromwebajaxsubmit = function () {
-		var tail = '&view=' + Joomla.apps.view;
+        [].slice.call(document.querySelectorAll('a.transcode')).forEach(function (element) {
+          var ajaxurl = element.getAttribute('href');
 
-		if (Joomla.apps.id) {
-			tail += '&id=' + Joomla.apps.id;
-		}
+          element.addEventListener('click', function (event) {
+            var pattern1 = new RegExp(webInstallerOptions.options.base_url);
+            var pattern2 = new RegExp('^index.php');
 
-		if (document.querySelector('#com-apps-searchbox').value) {
-			var value = encodeURI(document.querySelector('#com-apps-searchbox').value.toLowerCase().replace(/ +/g, '_').replace(/[^a-z0-9-_]/g, '').trim());
-			tail += '&filter_search=' + value;
-		}
+            if (pattern1.test(ajaxurl) || pattern2.test(ajaxurl)) {
+              webInstallerOptions.view = ajaxurl.replace(/^.+[&?]view=(\w+).*$/, '$1');
 
-		var ordering = Joomla.apps.ordering;
+              if (webInstallerOptions.view === 'dashboard') {
+                webInstallerOptions.id = 0;
+              } else if (webInstallerOptions.view === 'category') {
+                webInstallerOptions.id = ajaxurl.replace(/^.+[&?]id=(\d+).*$/, '$1');
+              }
 
-		if (ordering !== "" && document.querySelector('#com-apps-ordering').value) {
-			ordering = document.querySelector('#com-apps-ordering').value;
-		}
+              event.preventDefault();
+              self.loadweb(webInstallerOptions.options.base_url + ajaxurl);
+            } else {
+              event.preventDefault();
+              self.loadweb(ajaxurl);
+            }
+          });
 
-		if (ordering) {
-			tail += '&ordering=' + ordering;
-		}
+          element.setAttribute('href', '#');
+        });
+      }
+    }, {
+      key: 'initiateSearch',
+      value: function initiateSearch() {
+        webInstallerOptions.view = 'dashboard';
+        this.installfromwebajaxsubmit();
+      }
+    }, {
+      key: 'installfromwebajaxsubmit',
+      value: function installfromwebajaxsubmit() {
+        var tail = '&view=' + webInstallerOptions.view;
 
-		Joomla.loadweb(Joomla.apps.options.base_url + 'index.php?format=json&option=com_apps' + tail);
-	};
+        if (webInstallerOptions.id) {
+          tail += '&id=' + webInstallerOptions.id;
+        }
 
-	Joomla.apps.clickforlinks = function () {
-		[].slice.call(document.querySelectorAll('a.transcode')).forEach(element => {
-			var ajaxurl = element.getAttribute('href');
+        if (document.getElementById('com-apps-searchbox').value) {
+          var value = encodeURI(document.getElementById('com-apps-searchbox').value.toLowerCase().replace(/ +/g, '_').replace(/[^a-z0-9-_]/g, '').trim());
+          tail += '&filter_search=' + value;
+        }
 
-			element.addEventListener('click', function (event) {
-				var pattern1 = new RegExp(Joomla.apps.options.base_url);
-				var pattern2 = new RegExp("^index\.php");
+        if (webInstallerOptions.ordering !== '' && document.getElementById('com-apps-ordering').value) {
+          webInstallerOptions.ordering = document.getElementById('com-apps-ordering').value;
+        }
 
-				if (pattern1.test(ajaxurl) || pattern2.test(ajaxurl)) {
-					Joomla.apps.view = ajaxurl.replace(/^.+[&\?]view=(\w+).*$/, '$1');
+        if (webInstallerOptions.ordering) {
+          tail += '&ordering=' + webInstallerOptions.ordering;
+        }
 
-					if (Joomla.apps.view == 'dashboard') {
-						Joomla.apps.id = 0;
-					} else if (Joomla.apps.view == 'category') {
-						Joomla.apps.id = ajaxurl.replace(/^.+[&\?]id=(\d+).*$/, '$1');
-					}
+        this.loadweb(webInstallerOptions.options.base_url + 'index.php?format=json&option=com_apps' + tail);
+      }
+    }], [{
+      key: 'clicker',
+      value: function clicker() {
+        if (document.querySelector('.grid-view')) {
+          document.querySelector('.grid-view').addEventListener('click', function () {
+            webInstallerOptions.list = 0;
+            document.querySelector('.list-container').classList.add('hidden');
+            document.querySelector('.grid-container').classList.remove('hidden');
+            document.getElementById('btn-list-view').classList.remove('active');
+            document.getElementById('btn-grid-view').classList.remove('active');
+          });
+        }
 
-					event.preventDefault();
-					Joomla.loadweb(Joomla.apps.options.base_url + ajaxurl);
-				} else {
-					event.preventDefault();
-					Joomla.loadweb(ajaxurl);
-				}
-			});
+        if (document.querySelector('.list-view')) {
+          document.querySelector('.list-view').addEventListener('click', function () {
+            webInstallerOptions.list = 1;
+            document.querySelector('.grid-container').classList.add('hidden');
+            document.querySelector('.list-container').classList.remove('hidden');
+            document.getElementById('btn-grid-view').classList.remove('active');
+            document.getElementById('btn-list-view').classList.add('active');
+          });
+        }
+      }
 
-			element.setAttribute('href', '#');
-		});
-	};
+      /**
+       * @param {string} installUrl
+       * @param {string} name
+       * @returns {boolean}
+       * @todo Migrate this function's alert to a CE dialog
+       * @todo Migrate this function's hardcoded English string to Joomla.JText
+       */
 
-	Joomla.apps.initialize = function () {
-		Joomla.apps.loaded = 1;
+    }, {
+      key: 'installfromweb',
+      value: function installfromweb(installUrl, name) {
+        if (!installUrl) {
+          alert("This extension cannot be installed via the web. Please visit the developer's website to purchase/download.");
 
-		if (document.querySelector('#myTabContent')) {
-			var webTab = document.querySelector('#web');
+          return false;
+        }
 
-			webTab.insertAdjacentHTML('afterbegin', '<div id="appsloading" class="ifw-loading-container"></div>');
-			webTab.style.position = 'absolute';
+        var installUrlField = document.getElementById('install_url');
+        var uploadUrlContainer = document.getElementById('uploadform-web-url');
 
-			jQuery('#appsloading').on('ajaxStart', function () {
-				document.querySelector('body').classList.add('ifw-busy');
-				this.classList.remove('hidden');
-			}).on('ajaxStop', function () {
-				this.classList.add('hidden');
-				document.querySelector('body').classList.remove('ifw-busy');
-			});
-		}
+        installUrlField.value = installUrl;
+        uploadUrlContainer.innerHTML = installUrl;
 
-		Joomla.loadweb(Joomla.apps.options.base_url + 'index.php?format=json&option=com_apps&view=dashboard');
+        if (name) {
+          var nameElement = document.getElementById('uploadform-web-name');
+          nameElement.innerHTML = name;
+          document.getElementById('uploadform-web-name-label').classList.remove('hidden');
+        } else {
+          document.getElementById('uploadform-web-name-label').classList.add('hidden');
+        }
 
-		Joomla.apps.clickforlinks();
-	};
+        // jQuery('#jed-container').slideUp(300);
+        document.getElementById('uploadform-web').classList.remove('hidden');
 
-	Joomla.apps.initiateSearch = function () {
-		Joomla.apps.view = 'dashboard';
-		Joomla.installfromwebajaxsubmit();
-	};
+        return true;
+      }
 
-	Joomla.apps.clicker = function () {
-		if (document.querySelector(".grid-view")) {
-			document.querySelector(".grid-view").addEventListener("click", function () {
-				Joomla.apps.list = 0;
-				document.querySelector(".list-container").classList.add("hidden");
-				document.querySelector(".grid-container").classList.remove("hidden");
-				document.querySelector("#btn-list-view").classList.remove("active");
-				document.querySelector("#btn-grid-view").classList.remove("active");
-			});
-		}
+      /**
+       * Onclick handler for the button#appssubmitbutton element
+       *
+       * @param {string} redirectUrl
+       * @returns {boolean}
+       * @todo Convert from inline onclick registration, requires coordinated PR to IFW repo
+       * @todo Migrate this function's confirm to a CE dialog
+       * @todo Migrate this function's hardcoded English string to Joomla.JText
+       */
 
-		if (document.querySelector(".list-view")) {
-			document.querySelector(".list-view").addEventListener("click", function () {
-				Joomla.apps.list = 1;
-				document.querySelector(".grid-container").classList.add("hidden");
-				document.querySelector(".list-container").classList.remove("hidden");
-				document.querySelector("#btn-grid-view").classList.remove("active");
-				document.querySelector("#btn-list-view").classList.add("active");
-			});
-		}
-	};
+    }, {
+      key: 'installfromwebexternal',
+      value: function installfromwebexternal(redirectUrl) {
+        var redirectConfirm = confirm('You will be redirected to the following link to complete the registration/purchase - \n' + redirectUrl);
 
-	Joomla.submitbutton5 = function (pressbutton) {
-		var form = document.getElementById('adminForm');
+        if (redirectConfirm === true) {
+          document.getElementById('adminForm').setAttribute('action', redirectUrl);
+          document.querySelector('input[name=task]').setAttribute('disabled', true);
+          document.querySelector('input[name=install_directory]').setAttribute('disabled', true);
+          document.querySelector('input[name=install_url]').setAttribute('disabled', true);
+          document.querySelector('input[name=installtype]').setAttribute('disabled', true);
+          document.querySelector('input[name=filter_search]').setAttribute('disabled', true);
 
-		// do field validation
-		if (form.install_url.value !== "" && form.install_url.value !== "http://") {
-			Joomla.submitbutton4();
-		} else if (form.install_url.value === "") {
-			alert(Joomla.apps.options.btntxt);
-		} else {
-			document.querySelector('#appsloading').classList.remove('hidden');
-			form.installtype.value = 'web';
-			form.submit();
-		}
-	};
-})(window, document, Joomla, jQuery);
+          return true;
+        }
+
+        return false;
+      }
+    }]);
+
+    return WebInstaller;
+  }();
+
+  jQuery(function ($) {
+    var link = $('#myTabTabs').find('a[href="#web"]');
+
+    if (webInstallerOptions.options.installfromon) {
+      link.click();
+    }
+
+    if (link.hasClass('active')) {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    }
+
+    link.closest('li').click(function () {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    });
+
+    if (webInstallerOptions.options.installfrom_url !== '') {
+      link.closest('li').click();
+    }
+
+    link.on('shown.bs.tab', function () {
+      if (!instance) {
+        instance = new WebInstaller();
+        instance.initialise();
+      }
+    });
+  });
+})(window, document, Joomla, window.jQuery);

--- a/plugins/installer/webinstaller/tmpl/default.php
+++ b/plugins/installer/webinstaller/tmpl/default.php
@@ -40,7 +40,7 @@ $dir = $this->isRTL() ? ' dir="ltr"' : '';
 		<div class="card-body">
 			<div class="card-text">
 				<input type="button" class="btn btn-primary" value="<?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton<?php echo $this->getInstallFrom() != '' ? 4 : 5; ?>()" />
-				<input type="button" class="btn btn-secondary" value="<?php echo Text::_('JCANCEL'); ?>" onclick="Joomla.installfromwebcancel()" />
+				<input type="button" class="btn btn-secondary" id="uploadform-web-cancel" value="<?php echo Text::_('JCANCEL'); ?>" />
 			</div>
 		</div>
 	</div>

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -72,6 +72,8 @@ class PlgInstallerWebinstaller extends CMSPlugin
 	{
 		$installfrom = $this->getInstallFrom();
 
+		// TEMPORARY - Make sure Bootstrap is booted so that our client initialisation scripts can find the tab
+		HTMLHelper::_('bootstrap.framework');
 		HTMLHelper::_('script', 'plg_installer_webinstaller/client.min.js', ['version' => 'auto', 'relative' => true]);
 		HTMLHelper::_('stylesheet', 'plg_installer_webinstaller/client.min.css', ['version' => 'auto', 'relative' => true]);
 
@@ -98,42 +100,6 @@ class PlgInstallerWebinstaller extends CMSPlugin
 				'language'        => base64_encode($lang->getTag()),
 			]
 		);
-
-		$javascript = <<<END
-jQuery(document).ready(function ($) {
-	var options = Joomla.getOptions('plg_installer_webinstaller', {});
-
-	if (options.installfromon) {
-		$('#myTabTabs a[href="#web"]').click();
-	}
-
-	var link = $('#myTabTabs a[href="#web"]');
-
-	if (link.hasClass('active')) {
-		if (!Joomla.apps.loaded) {
-			Joomla.apps.initialize();
-		}
-	}
-
-	link.closest('li').click(function () {
-		if (!Joomla.apps.loaded) {
-			Joomla.apps.initialize();
-		}
-	});
-	
-	if (options.installfrom_url != '') {
-		link.closest('li').click();
-	}
-
-	$('#myTabTabs a[href="#web"]').on('shown.bs.tab', function () {
-		if (!Joomla.apps.loaded) {
-			Joomla.apps.initialize();
-		}
-	});
-});
-		
-END;
-		$doc->addScriptDeclaration($javascript);
 
 		$tab = [
 			'name'  => 'web',


### PR DESCRIPTION
Pull Request for Issue #24

Seeing as IFW has become my pet project, I've done the ES6 conversion plus some internal updates.

### Summary of Changes

- Migrated to ES6 constructs
    - Using a class because there are a lot of methods that have code paths that are dependent on one another, it's pretty much impossible to avoid `'foo' was used before it was defined` errors
- Removed unused code (after comparison against both the main CMS repo and the remote install from web repo as there is some JS functionality inlined into the markup responses generated from there)
- Flagged action items still needing attention, most of this requires coordinated changes across two repos and I'd rather this repo be the one with some broken stuff over the primary CMS repo for the moment
- Moved the remaining initialization script out of the plugin and into the JS file