### PR TITLE
Remove inline Javascript for administrator/components/com_plugins/tmpl/plugin/edit.php. (2)

### DIFF
--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -22,22 +22,6 @@ $input = JFactory::getApplication()->input;
 $isModal  = $input->get('layout') === 'modal' ? true : false;
 $layout   = $isModal ? 'modal' : 'edit';
 $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
-
-// Joomla4Upgrade TODO: Make work with J4 Modals
-JFactory::getDocument()->addScriptDeclaration("
-	Joomla.submitbutton = function(task) {
-		if (task === 'plugin.cancel' || document.formvalidator.isValid(document.getElementById('style-form'))) {
-			Joomla.submitform(task, document.getElementById('style-form'));
-		}
-
-		if (task !== 'plugin.apply') {
-			if (self !== top) {
-				window.top.setTimeout('window.parent.location = window.top.location.href', 1000);
-				window.parent.jQuery('#plugin" . $this->item->extension_id . "Modal').modal('hide');
-			}
-		}
-	};
-");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugin&layout=' . $layout . $tmpl . '&extension_id=' . (int) $this->item->extension_id); ?>" method="post" name="adminForm" id="style-form" class="form-validate">

--- a/administrator/components/com_redirect/Controller/DisplayController.php
+++ b/administrator/components/com_redirect/Controller/DisplayController.php
@@ -10,6 +10,7 @@ namespace Joomla\Component\Redirect\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Redirect\Administrator\Helper\RedirectHelper;
@@ -59,7 +60,7 @@ class DisplayController extends BaseController
 			else
 			{
 				$redirectPluginId = RedirectHelper::getRedirectPluginId();
-				$link = \JHtml::_(
+				$link = HTMLHelper::_(
 					'link',
 					'#plugin' . $redirectPluginId . 'Modal',
 					\JText::_('COM_REDIRECT_SYSTEM_PLUGIN'),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Deleted in-line JavaScript in com_plugin in the file edit.php.  
I think we do not need this JavaScript. The Modal in com_redirect works also without it. https://github.com/joomla-projects/joomla-es6/blob/dev/administrator/components/com_redirect/tmpl/links/default.php#L25

By the way I changed \JText in HTMLHelper in com_redirect.

###
See also: https://github.com/joomla-projects/joomla-es6/pull/59