### PR TITLE
Remove inline Javascript for administrator/components/com_plugins/tmpl/plugin/modal

### DIFF
--- a/administrator/components/com_plugins/tmpl/plugin/modal.php
+++ b/administrator/components/com_plugins/tmpl/plugin/modal.php
@@ -9,14 +9,6 @@
 
 defined('_JEXEC') or die;
 
-// This code is needed for proper check out in case of modal close
-JFactory::getDocument()->addScriptDeclaration('
-	window.parent.jQuery(".modal").on("hidden", function () {
-	if (typeof window.parent.jQuery("#plugin' . $this->item->extension_id . 'Modal iframe").contents().find("#closeBtn") !== "undefined") {
-		window.parent.jQuery("#plugin' . $this->item->extension_id . 'Modal iframe").contents().find("#closeBtn").click();
-		}
-	});
-');
 ?>
 <button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('plugin.apply');"></button>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('plugin.save');"></button>


### PR DESCRIPTION
### Summary of Changes

I deleted the Inline JavaScript in administrator/components/com_plugins/tmpl/plugin/modal.php as I think that we do not need it. 
You find a modal for com_plugins in com_redirect. This Modal works without the JavaScript.