### PR TITLE
Remove inline Javascript for administrator/components/com_menus/Field/MenutypeField.php

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -87,14 +87,6 @@ class MenutypeField extends \JFormFieldList
 		// Include jQuery
 		\JHtml::_('jquery.framework');
 
-		// Add the script to the document head.
-		Factory::getDocument()->addScriptDeclaration('
-			function jSelectPosition_' . $this->id . '(name) {
-				document.getElementById("' . $this->id . '").value = name;
-			}
-		'
-		);
-
 		$link = \JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla-projects/joomla-es6/issues/55 .

### Summary of Changes
I deleted the Inline JavaScript. As I see it, this is done by com_menus/admin-item-modal.js


### Testing Instructions
If you like to test, open menu manager and create an menu item and select a menu item type.
See that everything works fine.

