### PR TITLE
 Remove inline Javascript for administrator/components/com_joomlaupdate/tmpl/update/default.php

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
+
 // Include jQuery.
 JHtml::_('jquery.framework');
 
@@ -21,18 +24,12 @@ $filesize = JFactory::getApplication()->getUserState('com_joomlaupdate.filesize'
 $ajaxUrl = JUri::base() . 'components/com_joomlaupdate/restore.php';
 $returnUrl = 'index.php?option=com_joomlaupdate&task=update.finalise&' . JFactory::getSession()->getFormToken() . '=1';
 
-JFactory::getDocument()->addScriptDeclaration(
-	"
-	var joomlaupdate_password = '$password';
-	var joomlaupdate_totalsize = '$filesize';
-	var joomlaupdate_ajax_url = '$ajaxUrl';
-	var joomlaupdate_return_url = '$returnUrl';
+HTMLHelper::_('script', 'com_joomlaupdate/admin-update-default.js', ['relative' => true, 'version' => 'auto']);
 
-	jQuery(document).ready(function(){
-		window.pingExtract();
-		});
-	"
-);
+Factory::getDocument()->addScriptOptions('joomlaupdate_password', $password);
+Factory::getDocument()->addScriptOptions('joomlaupdate_totalsize', $filesize);
+Factory::getDocument()->addScriptOptions('joomlaupdate_ajax_url', $ajaxUrl);
+Factory::getDocument()->addScriptOptions('joomlaupdate_return_url', $returnUrl);
 ?>
 
 <p class="nowarning"><?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_INPROGRESS'); ?></p>

--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -26,10 +26,15 @@ $returnUrl = 'index.php?option=com_joomlaupdate&task=update.finalise&' . JFactor
 
 HTMLHelper::_('script', 'com_joomlaupdate/admin-update-default.js', ['relative' => true, 'version' => 'auto']);
 
-Factory::getDocument()->addScriptOptions('joomlaupdate_password', $password);
-Factory::getDocument()->addScriptOptions('joomlaupdate_totalsize', $filesize);
-Factory::getDocument()->addScriptOptions('joomlaupdate_ajax_url', $ajaxUrl);
-Factory::getDocument()->addScriptOptions('joomlaupdate_return_url', $returnUrl);
+Factory::getDocument()->addScriptOptions(
+	'joomlaupdate',
+	[
+		'password' => $password,
+		'totalsize' => $filesize,
+		'ajax_url' => $ajaxUrl,
+		'return_url' => $returnUrl,
+	]
+);
 ?>
 
 <p class="nowarning"><?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_INPROGRESS'); ?></p>

--- a/media/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/media/com_joomlaupdate/js/admin-update-default.es6.js
@@ -1,0 +1,16 @@
+/**
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+Joomla = window.Joomla || {};
+
+
+document.addEventListener('DOMContentLoaded', () => {
+  window.joomlaupdate_password = Joomla.getOptions('joomlaupdate_password');
+  window.joomlaupdate_totalsize = Joomla.getOptions('joomlaupdate_totalsize');
+  window.joomlaupdate_ajax_url = Joomla.getOptions('joomlaupdate_ajax_url');
+  window.joomlaupdate_return_url = Joomla.getOptions('joomlaupdate_return_url');
+  window.pingExtract();
+});
+

--- a/media/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/media/com_joomlaupdate/js/admin-update-default.es6.js
@@ -7,10 +7,11 @@ Joomla = window.Joomla || {};
 
 
 document.addEventListener('DOMContentLoaded', () => {
-  window.joomlaupdate_password = Joomla.getOptions('joomlaupdate_password');
-  window.joomlaupdate_totalsize = Joomla.getOptions('joomlaupdate_totalsize');
-  window.joomlaupdate_ajax_url = Joomla.getOptions('joomlaupdate_ajax_url');
-  window.joomlaupdate_return_url = Joomla.getOptions('joomlaupdate_return_url');
+  const JoomlaUpdateOptions = Joomla.getOptions('joomlaupdate');
+  window.joomlaupdate_password = JoomlaUpdateOptions.password;
+  window.joomlaupdate_totalsize = JoomlaUpdateOptions.totalsize;
+  window.joomlaupdate_ajax_url = JoomlaUpdateOptions.ajax_url;
+  window.joomlaupdate_return_url = JoomlaUpdateOptions.return_url;
   window.pingExtract();
 });
 

--- a/media/com_joomlaupdate/js/admin-update-default.js
+++ b/media/com_joomlaupdate/js/admin-update-default.js
@@ -1,0 +1,19 @@
+/**
+* PLEASE DO NOT MODIFY THIS FILE. WORK ON THE ES6 VERSION.
+* OTHERWISE YOUR CHANGES WILL BE REPLACED ON THE NEXT BUILD.
+**/
+
+/**
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+Joomla = window.Joomla || {};
+
+document.addEventListener('DOMContentLoaded', function () {
+  window.joomlaupdate_password = Joomla.getOptions('joomlaupdate_password');
+  window.joomlaupdate_totalsize = Joomla.getOptions('joomlaupdate_totalsize');
+  window.joomlaupdate_ajax_url = Joomla.getOptions('joomlaupdate_ajax_url');
+  window.joomlaupdate_return_url = Joomla.getOptions('joomlaupdate_return_url');
+  window.pingExtract();
+});

--- a/media/com_joomlaupdate/js/admin-update-default.js
+++ b/media/com_joomlaupdate/js/admin-update-default.js
@@ -4,16 +4,17 @@
 **/
 
 /**
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 Joomla = window.Joomla || {};
 
 document.addEventListener('DOMContentLoaded', function () {
-  window.joomlaupdate_password = Joomla.getOptions('joomlaupdate_password');
-  window.joomlaupdate_totalsize = Joomla.getOptions('joomlaupdate_totalsize');
-  window.joomlaupdate_ajax_url = Joomla.getOptions('joomlaupdate_ajax_url');
-  window.joomlaupdate_return_url = Joomla.getOptions('joomlaupdate_return_url');
+  var JoomlaUpdateOptions = Joomla.getOptions('joomlaupdate');
+  window.joomlaupdate_password = JoomlaUpdateOptions.password;
+  window.joomlaupdate_totalsize = JoomlaUpdateOptions.totalsize;
+  window.joomlaupdate_ajax_url = JoomlaUpdateOptions.ajax_url;
+  window.joomlaupdate_return_url = JoomlaUpdateOptions.return_url;
   window.pingExtract();
 });


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/joomla-es6/issues/55.

### Summary of Changes
 Remove inline Javascript for administrator/components/com_joomlaupdate/tmpl/update/default.php


### Test instructions

If you like to test go to com_joomlaupdater and pretend to start an update and see in debugger, that all variables are set and pingExtract() is run.