### PR TITLE
Remove inline Javascript for  administrator/components/com_fields/tmpl/fields/default_batch_body.php

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -14,24 +14,6 @@ JHtml::_('formbehavior.chosen', '.advancedSelect');
 
 HTMLHelper::_('script', 'com_fields/admin-fields-default-batch.js', ['relative' => true, 'version' => 'auto']);
 
-/*JFactory::getDocument()->addScriptDeclaration(
-	'
-		jQuery(document).ready(function($){
-			if ($("#batch-group-id").length){var batchSelector = $("#batch-group-id");}
-			if ($("#batch-copy-move").length) {
-				$("#batch-copy-move").hide();
-				batchSelector.on("change", function(){
-					if (batchSelector.val() != 0 || batchSelector.val() != "") {
-						$("#batch-copy-move").show();
-					} else {
-						$("#batch-copy-move").hide();
-					}
-				});
-			}
-		});
-	'
-);*/
-
 $context   = $this->escape($this->state->get('filter.context'));
 ?>
 

--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -2,14 +2,19 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_fields
- * 
+ *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+
 JHtml::_('formbehavior.chosen', '.advancedSelect');
-JFactory::getDocument()->addScriptDeclaration(
+
+HTMLHelper::_('script', 'com_fields/admin-fields-default-batch.js', ['relative' => true, 'version' => 'auto']);
+
+/*JFactory::getDocument()->addScriptDeclaration(
 	'
 		jQuery(document).ready(function($){
 			if ($("#batch-group-id").length){var batchSelector = $("#batch-group-id");}
@@ -25,7 +30,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			}
 		});
 	'
-);
+);*/
 
 $context   = $this->escape($this->state->get('filter.context'));
 ?>

--- a/media/com_fields/js/admin-fields-default-batch.es6.js
+++ b/media/com_fields/js/admin-fields-default-batch.es6.js
@@ -4,8 +4,8 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-  const batchSelector = document.querySelector('#batch-group-id');
-  const batchCopyMove = document.querySelector('#batch-copy-move');
+  const batchSelector = document.getElementById('batch-group-id');
+  const batchCopyMove = document.getElementById('batch-copy-move');
   batchCopyMove.style.display = 'none';
 
   batchSelector.addEventListener('change', () => {

--- a/media/com_fields/js/admin-fields-default-batch.es6.js
+++ b/media/com_fields/js/admin-fields-default-batch.es6.js
@@ -1,0 +1,18 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const batchSelector = document.querySelector('#batch-group-id');
+  const batchCopyMove = document.querySelector('#batch-copy-move');
+  batchCopyMove.style.display = 'none';
+
+  batchSelector.addEventListener('change', () => {
+    if (batchSelector.value === 'nogroup') {
+      batchCopyMove.style.display = 'block';
+    } else {
+      batchCopyMove.style.display = 'none';
+    }
+  }, false);
+});

--- a/media/com_fields/js/admin-fields-default-batch.js
+++ b/media/com_fields/js/admin-fields-default-batch.js
@@ -9,8 +9,8 @@
  */
 
 document.addEventListener('DOMContentLoaded', function () {
-  var batchSelector = document.querySelector('#batch-group-id');
-  var batchCopyMove = document.querySelector('#batch-copy-move');
+  var batchSelector = document.getElementById('batch-group-id');
+  var batchCopyMove = document.getElementById('batch-copy-move');
   batchCopyMove.style.display = 'none';
 
   batchSelector.addEventListener('change', function () {

--- a/media/com_fields/js/admin-fields-default-batch.js
+++ b/media/com_fields/js/admin-fields-default-batch.js
@@ -1,0 +1,23 @@
+/**
+* PLEASE DO NOT MODIFY THIS FILE. WORK ON THE ES6 VERSION.
+* OTHERWISE YOUR CHANGES WILL BE REPLACED ON THE NEXT BUILD.
+**/
+
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+document.addEventListener('DOMContentLoaded', function () {
+  var batchSelector = document.querySelector('#batch-group-id');
+  var batchCopyMove = document.querySelector('#batch-copy-move');
+  batchCopyMove.style.display = 'none';
+
+  batchSelector.addEventListener('change', function () {
+    if (batchSelector.value === 'nogroup') {
+      batchCopyMove.style.display = 'block';
+    } else {
+      batchCopyMove.style.display = 'none';
+    }
+  }, false);
+});


### PR DESCRIPTION
Pull Request for Issue 
https://github.com/joomla-projects/joomla-es6/issues/55

### Summary of Changes
Remove Inline JavaScript, remove jQuery, es6

### Testing Instructions
If you like to test open com_fields and select some fields. Click the toolbar button batch and see, that the field #batch-copy-move is hide and show like expected.


