### PR TITLE
Remove inline Javascript for administrator/components/com_fields/tmpl/field/edit.php

### DIFF
--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -8,6 +8,8 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
@@ -19,19 +21,7 @@ JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_thre
 $app = JFactory::getApplication();
 $input = $app->input;
 
-JFactory::getDocument()->addScriptDeclaration('
-	jQuery(document).ready(function() {
-		jQuery("#jform_title").data("dp-old-value", jQuery("#jform_title").val());
-		jQuery("#jform_title").change(function(data, handler) {
-			if(jQuery("#jform_title").data("dp-old-value") == jQuery("#jform_label").val()) {
-				jQuery("#jform_label").val(jQuery("#jform_title").val());
-			}
-
-			jQuery("#jform_title").data("dp-old-value", jQuery("#jform_title").val());
-		});
-	});
-');
-
+HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, 'version' => 'auto']);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_fields&context=' . $input->getCmd('context', 'com_content') . '&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/media/com_fields/js/admin-field-edit.es6.js
+++ b/media/com_fields/js/admin-field-edit.es6.js
@@ -1,0 +1,20 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const title = document.getElementById('jform_title');
+  title.dpOldValue = title.value;
+
+  title.addEventListener('change', (event) => {
+    const label = document.getElementById('jform_label');
+    const changedTitle = event.currentTarget;
+
+    if (changedTitle.dpOldValue === label.value) {
+      label.value = changedTitle.value;
+    }
+
+    changedTitle.dpOldValue = changedTitle.value;
+  });
+});

--- a/media/com_fields/js/admin-field-edit.js
+++ b/media/com_fields/js/admin-field-edit.js
@@ -1,0 +1,25 @@
+/**
+* PLEASE DO NOT MODIFY THIS FILE. WORK ON THE ES6 VERSION.
+* OTHERWISE YOUR CHANGES WILL BE REPLACED ON THE NEXT BUILD.
+**/
+
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+document.addEventListener('DOMContentLoaded', function () {
+  var title = document.getElementById('jform_title');
+  title.dpOldValue = title.value;
+
+  title.addEventListener('change', function (event) {
+    var label = document.getElementById('jform_label');
+    var changedTitle = event.currentTarget;
+
+    if (changedTitle.dpOldValue === label.value) {
+      label.value = changedTitle.value;
+    }
+
+    changedTitle.dpOldValue = changedTitle.value;
+  });
+});


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/joomla-es6/issues/55.

### Summary of Changes
Remove inline Javascript for administrator/components/com_fields/tmpl/field/edit.php


### Testing Instructions
If you like to test open com_fields and create a new field. Enter the title and see, that the label synchronized with the title as long as you do not change the label itself.

